### PR TITLE
Implement USB-CDC ACM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/PocketSprite/UGUI.git
 [submodule "TinyFPGA-Bootloader"]
 	path = TinyFPGA-Bootloader
-	url = git@github.com:Spritetm/hadbadge2019_tinyfpgabootloader.git
+	url = https://github.com/Spritetm/hadbadge2019_tinyfpgabootloader.git
 [submodule "soc/app/tinyusb"]
 	path = soc/ipl/tinyusb
 	url = https://github.com/hathach/tinyusb.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/PocketSprite/UGUI.git
 [submodule "TinyFPGA-Bootloader"]
 	path = TinyFPGA-Bootloader
-	url = https://github.com/Spritetm/hadbadge2019_tinyfpgabootloader.git
+	url = git@github.com:Spritetm/hadbadge2019_tinyfpgabootloader.git
 [submodule "soc/app/tinyusb"]
 	path = soc/ipl/tinyusb
 	url = https://github.com/hathach/tinyusb.git

--- a/soc/ipl/Makefile
+++ b/soc/ipl/Makefile
@@ -27,7 +27,7 @@ OBJS += tjftl/tjftl.o fs.o
 LIBS := gloss/libgloss.a
 LDSCRIPT := gloss/ldscript.ld
 
-CFLAGS := -Os -ggdb -I. -IUGUI -Iusb -Igloss -Itinyusb/src -Ifatfs/source
+CFLAGS := -Os -ggdb -I. -IUGUI -Iusb -Igloss -Itinyusb/src -Ifatfs/source -I../tinyusb/src -I../
 LDFLAGS := -Wl,-Bstatic -Wl,--gc-sections  -Wl,-T,$(LDSCRIPT) -Wl,-Map,$(TARGET_MAP) -lgcc -nostartfiles -Lgloss 
 export PREFIX CC AR LD OBJCOPY CFLAGS LDFLAGS APPNAME
 

--- a/soc/ipl/gloss/newlib_stubs.c
+++ b/soc/ipl/gloss/newlib_stubs.c
@@ -16,6 +16,8 @@
 #include "../fatfs/source/ff.h"
 #include "../loadapp.h"
 
+#include "tusb.h"
+
 int remap_fatfs_errors(FRESULT f) {
 	if (f==FR_OK) return 0;
 	switch (f) {
@@ -37,7 +39,8 @@ int remap_fatfs_errors(FRESULT f) {
 }
 
 #define FD_TYPE_DBGUART 0
-#define FD_TYPE_FATFS 1
+#define FD_TYPE_USBUART 1
+#define FD_TYPE_FATFS 2
 
 #define FD_FLAG_OPEN (1<<0)
 #define FD_FLAG_WRITABLE (1<<1)
@@ -99,23 +102,32 @@ int _open(const char *name, int flags, int mode) {
 		errno=ENFILE;
 		return -1;
 	}
-	int fmode=0;
-	if (flags & O_APPEND) fmode|=FA_OPEN_APPEND;
-	if (flags & O_CREAT) fmode|=FA_OPEN_ALWAYS;
-	if (flags & O_EXCL) fmode|=FA_CREATE_NEW;
-	if (flags & O_TRUNC) fmode|=FA_CREATE_ALWAYS;
-	//madness, O_RDONLY=0, O_WRONLY=1, O_RDWR=2. Adding one makes it into a bitmap.
-	if ((flags+1) & (O_RDONLY+1)) fmode|=FA_READ;
-	if ((flags+1) & (O_WRONLY+1)) fmode|=FA_WRITE;
-	fd_entry[i].fatfcb=calloc(sizeof(FIL), 1);
-	FRESULT r=f_open(fd_entry[i].fatfcb, name, fmode);
-	if (r==F_OK) {
-		fd_entry[i].flags=FD_FLAG_OPEN;
-		fd_entry[i].type=FD_TYPE_FATFS;
+	// Special cases for USB-UART
+	if (!strcmp(name, "/dev/ttyUSB")) {
+		fd_entry[i].type=FD_TYPE_USBUART;
+		fd_entry[i].flags=FD_FLAG_OPEN|FD_FLAG_WRITABLE;
+	} else if (!strcmp(name, "/dev/ttyserial")){
+		fd_entry[i].type=FD_TYPE_DBGUART;
+		fd_entry[i].flags=FD_FLAG_OPEN|FD_FLAG_WRITABLE;
 	} else {
-		i=-1;
+		int fmode=0;
+		if (flags & O_APPEND) fmode|=FA_OPEN_APPEND;
+		if (flags & O_CREAT) fmode|=FA_OPEN_ALWAYS;
+		if (flags & O_EXCL) fmode|=FA_CREATE_NEW;
+		if (flags & O_TRUNC) fmode|=FA_CREATE_ALWAYS;
+		//madness, O_RDONLY=0, O_WRONLY=1, O_RDWR=2. Adding one makes it into a bitmap.
+		if ((flags+1) & (O_RDONLY+1)) fmode|=FA_READ;
+		if ((flags+1) & (O_WRONLY+1)) fmode|=FA_WRITE;
+		fd_entry[i].fatfcb=calloc(sizeof(FIL), 1);
+		FRESULT r=f_open(fd_entry[i].fatfcb, name, fmode);
+		if (r==F_OK) {
+			fd_entry[i].flags=FD_FLAG_OPEN;
+			fd_entry[i].type=FD_TYPE_FATFS;
+		} else {
+			i=-1;
+		}
+		remap_fatfs_errors(r);
 	}
-	remap_fatfs_errors(r);
 	return i;
 }
 
@@ -157,6 +169,8 @@ ssize_t _write(int file, const void *ptr, size_t len) {
 	if (fd_entry[file].type==FD_TYPE_DBGUART) {
 		uart_write((const char*)ptr, len);
 		return len;
+	} else if (fd_entry[file].type==FD_TYPE_USBUART) {
+		return tud_cdc_write(ptr, len);
 	} else if (fd_entry[file].type==FD_TYPE_FATFS) {
 		UINT rlen;
 		FRESULT r=f_write(fd_entry[file].fatfcb, ptr, len, &rlen);

--- a/soc/ipl/gloss/newlib_stubs.c
+++ b/soc/ipl/gloss/newlib_stubs.c
@@ -105,10 +105,12 @@ int _open(const char *name, int flags, int mode) {
 	// Special cases for USB-UART
 	if (!strcmp(name, "/dev/ttyUSB")) {
 		fd_entry[i].type=FD_TYPE_USBUART;
-		fd_entry[i].flags=FD_FLAG_OPEN|FD_FLAG_WRITABLE;
+		fd_entry[i].flags=FD_FLAG_OPEN;
+		if ((flags+1) & (O_WRONLY+1)) fd_entry[i].flags|=FD_FLAG_WRITABLE;
 	} else if (!strcmp(name, "/dev/ttyserial")){
 		fd_entry[i].type=FD_TYPE_DBGUART;
-		fd_entry[i].flags=FD_FLAG_OPEN|FD_FLAG_WRITABLE;
+		fd_entry[i].flags=FD_FLAG_OPEN;
+		if ((flags+1) & (O_WRONLY+1)) fd_entry[i].flags|=FD_FLAG_WRITABLE;
 	} else {
 		int fmode=0;
 		if (flags & O_APPEND) fmode|=FA_OPEN_APPEND;

--- a/soc/ipl/main.c
+++ b/soc/ipl/main.c
@@ -1,5 +1,7 @@
 #include <stdint.h>
 #include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include "gloss/mach_defines.h"
 #include "gloss/uart.h"
 #include <stdio.h>
@@ -74,6 +76,8 @@ void start_app(char *app) {
 	printf("App returned.\n");
 }
 
+void cdc_task();
+
 void main() {
 	syscall_reinit();
 	printf("IPL running.\n");
@@ -123,7 +127,49 @@ void main() {
 		cache_flush(lcdfb, lcdfb+320*480/2);
 		for (int i=0; i<500; i++) {
 			usb_poll();
+			cdc_task();
 			tud_task();
 		}
 	}
+}
+
+void cdc_task(void)
+{
+	if ( tud_cdc_connected() )
+	{
+		tud_cdc_write_flush();
+	}
+}
+
+// Invoked when cdc when line state changed e.g connected/disconnected
+void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
+{
+  (void) itf;
+
+  // connected
+	if ( dtr )
+	{
+		// print initial message when connected
+		tud_cdc_write_str("TinyUSB CDC MSC HID device example\r\n");
+
+		// switch stdout/stdin/stderr
+		for (int i=0;i<3;i++) {
+			close(i);
+			open("/dev/ttyUSB", O_RDWR);
+		}
+	}
+
+	if (!dtr) {
+		// switch back to serial
+		for (int i=0;i<3;i++) {
+			close(i);
+			open("/dev/ttyserial", O_RDWR);
+		}
+	}
+}
+
+// Invoked when CDC interface received data from host
+void tud_cdc_rx_cb(uint8_t itf)
+{
+	(void) itf;
 }

--- a/soc/ipl/tusb_config.h
+++ b/soc/ipl/tusb_config.h
@@ -70,7 +70,7 @@
 #define CFG_TUD_ENDOINT0_SIZE       64
 
 //------------- CLASS -------------//
-#define CFG_TUD_CDC                 0
+#define CFG_TUD_CDC                 1
 #define CFG_TUD_MSC                 1
 #define CFG_TUD_HID                 0
 


### PR DESCRIPTION
This PR enables CDC ACM on the TinyUSB USB stack and also adds support for stdio redirection for printf statements.