### PR TITLE
Refactor extern mapped section definitions into a sdk.h header

### DIFF
--- a/app-basic/ext_btn.c
+++ b/app-basic/ext_btn.c
@@ -1,11 +1,8 @@
 #include "ext_btn.h"
 #include <assert.h>
 #include "mach_defines.h"
+#include "sdk.h"
 #include <stdint.h>
-
-extern volatile uint32_t MISC[];
-#define MISC_REG(i) MISC[(i)/4]
-
 
 static int _buttons(struct mb_interpreter_t* s, void** l) {
 	int result = MB_FUNC_OK;

--- a/app-helloworld/main.c
+++ b/app-helloworld/main.c
@@ -3,19 +3,9 @@
 #include <stdio.h>
 
 #include "mach_defines.h"
+#include "sdk.h"
 #include "gfx_load.h"
 #include "cache.h"
-
-//hardware addresses I really need to dump into an include or something...
-extern volatile uint32_t MISC[];
-#define MISC_REG(i) MISC[(i)/4]
-extern volatile uint32_t GFXREG[];
-#define GFX_REG(i) GFXREG[(i)/4]
-extern uint32_t GFXPAL[];
-extern uint32_t GFXTILES[];
-extern uint32_t GFXTILEMAPA[];
-extern uint32_t GFXTILEMAPB[];
-
 
 //The bgnd.png image got linked into the binary of this app, and these two chars are the first
 //and one past the last byte of it.

--- a/apps-sdk/sdk.h
+++ b/apps-sdk/sdk.h
@@ -1,0 +1,33 @@
+#ifndef HACKADAY_SOC_SDK_H
+#define HACKADAY_SOC_SDK_H
+
+#include <stdint.h>
+
+// these hardware addresses are resolved at link time from
+// the ldscript.ld in the gloss folder and map to virtual
+// support hardware defined for the default RISC-V SOC
+
+// see soc/ipl/gloss/mach_defines.h for information on
+// the various register offsets and values
+
+extern volatile uint32_t MISC[];
+#define MISC_REG(i) MISC[(i)/4]
+
+extern volatile uint32_t UART;
+#define UART_REG(i) UART[(i)/4]
+
+extern volatile uint32_t LCD;
+#define LCD_REG(i) LCD[(i)/4]
+
+extern volatile uint32_t USB;
+#define USB_REG(i) USB[(i)/4]
+
+extern volatile uint32_t GFXREG[];
+#define GFX_REG(i) GFXREG[(i)/4]
+
+extern uint32_t GFXPAL[];
+extern uint32_t GFXTILES[];
+extern uint32_t GFXTILEMAPA[];
+extern uint32_t GFXTILEMAPB[];
+
+#endif // HACKADAY_SOC_SDK_H


### PR DESCRIPTION
Make use of this header in app-helloworld and app-basic