### PR TITLE
{video,lcd}_renderer.cpp: Fix SDL refresh bug

### DIFF
--- a/soc/video/lcd_renderer.cpp
+++ b/soc/video/lcd_renderer.cpp
@@ -61,7 +61,7 @@ void Lcd_renderer::update(int db, int wr, int rd, int rs) {
 			Uint32 time_since_last=SDL_GetTicks()-last_update;
 			if (time_since_last>100) {
 				SDL_UpdateWindowSurface(window);
-				time_since_last=SDL_GetTicks();
+				last_update=SDL_GetTicks();
 			}
 			xpos=0;
 			ypos++;

--- a/soc/video/video_renderer.cpp
+++ b/soc/video/video_renderer.cpp
@@ -66,7 +66,7 @@ int Video_renderer::next_pixel(int red, int green, int blue, int *fetch_next, in
 			Uint32 time_since_last=SDL_GetTicks()-last_update;
 			if (time_since_last>100) {
 				SDL_UpdateWindowSurface(window);
-				time_since_last=SDL_GetTicks();
+				last_update=SDL_GetTicks();
 			}
 		}
 		beam_x=0;


### PR DESCRIPTION
Bug caused very slow performance as SDL surface was updated on every line.