### PR TITLE
Make easier to write test benches with soc/video verilator code

### DIFF
--- a/soc/video/Makefile
+++ b/soc/video/Makefile
@@ -1,9 +1,13 @@
-SRC := ram_dp_24x2048_sim.v video_mem.v vid_linerenderer.v vid.v video_renderer.cpp verilator_main.cpp ../qpi_cache/qpimem_dma_rdr.v
+SRC := ram_dp_24x2048_sim.v video_mem.v vid_linerenderer.v vid.v ../qpi_cache/qpimem_dma_rdr.v
 SRC += vid_palettemem_sim.v vid_tilemapmem_sim.v vid_tilemem_sim.v vgapal.c ../mul_18x18_sim.v
 SRC += vid_spriteeng.v vid_sprite_linebuf_sim.v vid_spritemem_sim.v
+
+SRC_SIM := video_renderer.cpp verilator_main.cpp verilator_options.cpp
+
 verilator: verilator-build/Vvid $(EXTRA_DEPEND)
 	./verilator-build/Vvid
 
 verilator-build/Vvid: $(SRC) $(SRC_SIM) $(BRAMFILE)
-	verilator -CFLAGS "-ggdb `sdl2-config --cflags`" -LDFLAGS "`sdl2-config --libs` -lgd" --assert --trace --Mdir verilator-build -Wno-style -Wno-fatal -cc --top-module vid --exe $(SRC) $(SRC_SIM)
+	verilator -CFLAGS "-ggdb `sdl2-config --cflags`" -LDFLAGS "`sdl2-config --libs` -lgd" --assert --trace \
+		--Mdir verilator-build -Wno-style -Wno-fatal -cc --top-module vid --exe $(SRC) $(SRC_SIM)
 	make OPT_FAST="-Og -fno-stack-protector" -C verilator-build -f Vvid.mk

--- a/soc/video/Makefile
+++ b/soc/video/Makefile
@@ -2,7 +2,7 @@ SRC := ram_dp_24x2048_sim.v video_mem.v vid_linerenderer.v vid.v ../qpi_cache/qp
 SRC += vid_palettemem_sim.v vid_tilemapmem_sim.v vid_tilemem_sim.v vgapal.c ../mul_18x18_sim.v
 SRC += vid_spriteeng.v vid_sprite_linebuf_sim.v vid_spritemem_sim.v
 
-SRC_SIM := video_renderer.cpp verilator_main.cpp verilator_options.cpp
+SRC_SIM := video_renderer.cpp verilator_main.cpp verilator_options.cpp verilator_setup.cpp
 
 verilator: verilator-build/Vvid $(EXTRA_DEPEND)
 	./verilator-build/Vvid
@@ -11,3 +11,8 @@ verilator-build/Vvid: $(SRC) $(SRC_SIM) $(BRAMFILE)
 	verilator -CFLAGS "-ggdb `sdl2-config --cflags`" -LDFLAGS "`sdl2-config --libs` -lgd" --assert --trace \
 		--Mdir verilator-build -Wno-style -Wno-fatal -cc --top-module vid --exe $(SRC) $(SRC_SIM)
 	make OPT_FAST="-Og -fno-stack-protector" -C verilator-build -f Vvid.mk
+
+clean:
+	rm -rf verilator-build
+
+.PHONY: clean

--- a/soc/video/verilator_main.cpp
+++ b/soc/video/verilator_main.cpp
@@ -2,6 +2,8 @@
 #include "Vvid.h"
 #include <verilated.h>
 #include <verilated_vcd_c.h>
+
+#include "verilator_options.hpp"
 #include "video_renderer.hpp"
 #include <gd.h>
 #include <stdint.h>
@@ -134,6 +136,8 @@ void qpi_eval(int clk, int qpi_addr, int qpi_do_read, int *qpi_is_idle, int *qpi
 }
 
 int main(int argc, char **argv) {
+	CmdLineOptions options = CmdLineOptions::parse(argc, argv);
+
 	// Initialize Verilators variables
 	Verilated::commandArgs(argc, argv);
 	Verilated::traceEverOn(true);
@@ -211,7 +215,7 @@ int main(int argc, char **argv) {
 
 	// Main loop - count fields
 	int field = 0;
-	while (field < 3) {
+	while (field < options.num_fields) {
 		// Toggle main clock high
 		tb->pixelclk = (pixelclk_pos>0.5)?1:0;
 		tb->clk = !tb->clk;

--- a/soc/video/verilator_options.cpp
+++ b/soc/video/verilator_options.cpp
@@ -4,15 +4,17 @@
 #include <stdlib.h>
 
 CmdLineOptions::CmdLineOptions(): 
-	num_fields(3) {}
+	num_fields(3), trace_on(false) {}
 
 void CmdLineOptions::dump() {
-	printf("CmdLineOptions{%u}", num_fields);
+	printf("CmdLineOptions{%u, %s}", num_fields, trace_on ? "true" : "false");
 }
 
 static void errExit(char *prog_name, const char *msg, char opt) {
     fprintf(stderr, "Option '%c': %s\n"
-    	"Usage: %s [-f fields]\n",
+    	"Usage: %s [-f fields] [-t]\n"
+    	"  -f: number of HDMI fields to run consecutively\n"
+    	"  -t: trace execution to a .vcd file\n",
     	   opt, msg, prog_name);
     exit(EXIT_FAILURE);	
 }
@@ -33,10 +35,13 @@ static unsigned int readPosNum(char *prog_name, char opt, char *s) {
 CmdLineOptions CmdLineOptions::parse(int argc, char**argv) {
 	CmdLineOptions result;
 	int opt;
-	while ((opt = getopt(argc, argv, "f:")) != -1) {
+	while ((opt = getopt(argc, argv, "f:t")) != -1) {
     	switch (opt) {
 		case 'f':
 			result.num_fields = readPosNum(argv[0], 'f', optarg);
+			break;
+		case 't':
+			result.trace_on = true;
 			break;
         default: /* '?' */
             errExit(argv[0], "Unknown", opt);

--- a/soc/video/verilator_options.cpp
+++ b/soc/video/verilator_options.cpp
@@ -1,0 +1,46 @@
+#include "verilator_options.hpp"
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+CmdLineOptions::CmdLineOptions(): 
+	num_fields(3) {}
+
+void CmdLineOptions::dump() {
+	printf("CmdLineOptions{%u}", num_fields);
+}
+
+static void errExit(char *prog_name, const char *msg, char opt) {
+    fprintf(stderr, "Option '%c': %s\n"
+    	"Usage: %s [-f fields]\n",
+    	   opt, msg, prog_name);
+    exit(EXIT_FAILURE);	
+}
+
+static unsigned int readPosNum(char *prog_name, char opt, char *s) {
+	if (s == NULL) {
+		errExit(prog_name, "Must provide a positive number", opt);
+		return 0;
+	}
+	unsigned int result = atoi(s);
+	if (result <= 0) {
+		errExit(prog_name, "Must provide a positive number", opt);
+		return 0;
+	}
+	return result;
+}
+
+CmdLineOptions CmdLineOptions::parse(int argc, char**argv) {
+	CmdLineOptions result;
+	int opt;
+	while ((opt = getopt(argc, argv, "f:")) != -1) {
+    	switch (opt) {
+		case 'f':
+			result.num_fields = readPosNum(argv[0], 'f', optarg);
+			break;
+        default: /* '?' */
+            errExit(argv[0], "Unknown", opt);
+		}
+	}
+	return result;
+}

--- a/soc/video/verilator_options.hpp
+++ b/soc/video/verilator_options.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+// Contains found command line options
+class CmdLineOptions {
+public:
+	CmdLineOptions();
+
+	// Option fields - all public
+	// For how many fields to run
+	unsigned int num_fields;
+
+	// Factory method: creates from command line
+	static CmdLineOptions parse(int argc, char**argv);
+
+	// Dumps value to stdout
+	void dump();
+};
+

--- a/soc/video/verilator_options.hpp
+++ b/soc/video/verilator_options.hpp
@@ -9,6 +9,9 @@ public:
 	// For how many fields to run
 	unsigned int num_fields;
 
+	// Whether we should trace (generates large files)
+	bool trace_on;
+
 	// Factory method: creates from command line
 	static CmdLineOptions parse(int argc, char**argv);
 

--- a/soc/video/verilator_options.hpp
+++ b/soc/video/verilator_options.hpp
@@ -1,5 +1,14 @@
 #pragma once
 
+// Setup function routines
+typedef void (*setup_fn)();
+
+// This is defined in verilator_main.cpp
+// Null terminated array of pointers. Assume has at least one non-null entry
+extern setup_fn setups[];
+
+unsigned int setup_count();
+
 // Contains found command line options
 class CmdLineOptions {
 public:
@@ -8,6 +17,9 @@ public:
 	// Option fields - all public
 	// For how many fields to run
 	unsigned int num_fields;
+
+	// Which setup function to run
+	setup_fn setup = setups[0];
 
 	// Whether we should trace (generates large files)
 	bool trace_on;

--- a/soc/video/verilator_setup.cpp
+++ b/soc/video/verilator_setup.cpp
@@ -1,0 +1,85 @@
+#include "verilator_setup.hpp"
+#include "vgapal.h"
+
+// Trace globals
+uint64_t ts=0;
+double sc_time_stamp() {
+	return ts;
+}
+Vvid *tb = NULL;
+VerilatedVcdC *trace = NULL;
+
+// Evaluate model, advance time and optionally trace
+void tb_step(bool trace_exempt) { 
+	tb->eval(); 
+	if (trace && !trace_exempt) trace->dump(ts); 
+	ts++;
+}
+
+// Create the test bench
+void init_test_bench(bool trace_on) {
+	tb = new Vvid;
+	if (trace_on) {
+		trace = new VerilatedVcdC;
+		tb->trace(trace, 99);
+		trace->open("vidtrace.vcd");
+	}
+}
+
+// Clock data out to a given register in video subsystem.
+void tb_write(int addr, int data, bool trace_exempt) {
+	tb->addr=addr;
+	tb->din=data;
+	tb->wstrb=0xf;
+	do {
+		tb->eval();
+		tb->clk=1;
+		tb_step(trace_exempt);
+		tb->clk=0;
+		tb_step(trace_exempt);
+	} while (tb->ready==0);
+	tb->wstrb=0x0;
+}
+
+// Send reset signal to test bench
+void toggle_reset() {
+	tb->reset=1;
+	tb->ren=0;
+	for (int i=0; i<16; i++) {
+		tb->clk = 1;
+		tb_step();
+		tb->clk = 0;
+		tb_step();
+		if (i==8) tb->reset=0;
+	}	
+}
+
+// Load a default palette
+void load_default_palette() {
+	// Set first 256 colors of palette to standard VGA colors 
+	for (int i=0; i<256; i++) {
+		int p;
+		p=vgapal[i*3];
+		p|=vgapal[i*3+1]<<8;
+		p|=vgapal[i*3+2]<<16;
+		p|=(0xff<<24);
+		tb_write(PAL_OFF+(i*4), p);
+		tb_write(PAL_OFF+((i+256)*4), p);
+	}
+
+	// Set some of the remaining palette colors
+	tb_write(PAL_OFF+(0x100*4), 0xffff00ff);
+	tb_write(PAL_OFF+((0x1ff)*4), 0x10ff00ff);
+}
+
+// Set a sprite's position, scale and tile number
+void set_sprite(int no, int x, int y, int sx, int sy, int tileno) {
+	uint32_t sa, sb;
+	x+=64;
+	y+=64;
+	sa=(y<<16)|x;
+	sb=sx|(sy<<8)|(tileno<<16);
+	printf("Sprite %d: %08X %08X\n", no, sa, sb);
+	tb_write(SPRITE_OFF+no*8, sa);
+	tb_write(SPRITE_OFF+no*8+4, sb);
+}

--- a/soc/video/verilator_setup.cpp
+++ b/soc/video/verilator_setup.cpp
@@ -83,3 +83,28 @@ void set_sprite(int no, int x, int y, int sx, int sy, int tileno) {
 	tb_write(SPRITE_OFF+no*8, sa);
 	tb_write(SPRITE_OFF+no*8+4, sb);
 }
+
+// Load a tile into memory from a 256 char string
+// 0-9a-f are the 16 colors. 
+// A-F aliases a-f
+// All other characters -> lower 4 bits are used
+void load_tile(int tile, const char *s) {
+	uint32_t eight_pix;
+	for (int i = 0; s[i] && i < 256; i++) {
+		char c = s[i];
+		int v = 0;
+		if ('a' <= c && c <= 'f') {
+			v = c - 'a' + 10;
+		} else if ('A' <= c && c <= 'F') {
+			v = c - 'A' + 10;
+		} else {
+			v = c & 0xf;
+		}
+		eight_pix = (v << 28) | (eight_pix >> 4);
+		if (i % 8 == 7) {
+			uint32_t addr = TILEMEM_OFF+(tile*32+i/8)*4;
+			tb_write(addr, eight_pix);
+		}
+
+	}
+}

--- a/soc/video/verilator_setup.hpp
+++ b/soc/video/verilator_setup.hpp
@@ -39,3 +39,9 @@ void load_default_palette();
 
 // Set a sprite's position, scale and tile number
 void set_sprite(int no, int x, int y, int sx, int sy, int tileno);
+
+// Load a tile into memory from a 256 char string
+// 0-9a-f are the 16 colors. 
+// A-F aliases a-f
+// All other characters -> lower 4 bits are used
+void load_tile(int no, const char *s);

--- a/soc/video/verilator_setup.hpp
+++ b/soc/video/verilator_setup.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Vvid.h"
+#include <verilated_vcd_c.h>
+
+// These match constants from ../../ipl/gloss/mach_defines.h
+#define REG_OFF 0x0000
+#define PAL_OFF 0x2000
+#define TILEMAPA_OFF 0x4000
+#define TILEMAPB_OFF 0x8000
+#define SPRITE_OFF 0xC000
+#define TILEMEM_OFF 0x10000
+
+// Trace machinery
+extern uint64_t ts;
+double sc_time_stamp();
+// tb (test bench) contains a line renderer and video memory controller
+extern Vvid *tb;
+// trace is non-null if verilator tracing is on
+extern VerilatedVcdC *trace;
+
+// Evaluate model, advance time and optionally trace
+void tb_step(bool trace_exempt=false);
+
+// Create the test bench
+void init_test_bench(bool trace_on);
+
+// Clock data out to a given register in video subsystem.
+// This clocks the video testbench main clock without also updating pixelclk.
+// For this reason, updates made while system is processing main loop may not
+// be properly interpreted.
+void tb_write(int addr, int data, bool trace_exempt=false);
+
+// Send reset signal to test bench
+void toggle_reset();
+
+// Load a default palette
+void load_default_palette();
+
+// Set a sprite's position, scale and tile number
+void set_sprite(int no, int x, int y, int sx, int sy, int tileno);

--- a/soc/video/vgapal.h
+++ b/soc/video/vgapal.h
@@ -1,1 +1,3 @@
+// VGA mode 13h colors
+// 256 * 3byte entries
 extern unsigned char vgapal[];


### PR DESCRIPTION
Updates the soc/video verilator_main code with the intention of making it easier to set up test benches

- add command line flags 
- provide a way to switch between multiple "setups"
- finish simulation after a configurable number of frames
- make tracing optional

Example command line: 

$ make verilator-build/Vvid && ./verilator-build/Vvid -f 2 -s 2