### PR TITLE
Multilib flag for building RISC-V toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Specifically, you want a multilib Newlib toolchain, something that is not in the
 invoke these two commands after having fulfilled all prerequisites and you should be good:
 
 ```
-./configure --prefix=/opt/riscv
+./configure --prefix=/opt/riscv --enable-multilib
 make
 ```
 


### PR DESCRIPTION
Build configuration needs multilib flag to match text "you want a multilib Newlib toolchain"

Have verified `make` in `/soc/ipl` would fail if ```--enable-multilib``` is missing.