### PR TITLE
Add support for DFU Runtime interface

### DIFF
--- a/soc/ipl/Makefile
+++ b/soc/ipl/Makefile
@@ -12,6 +12,7 @@ OBJS += tinyusb/src/device/usbd.o tinyusb/src/device/usbd_control.o tinyusb/src/
 OBJS += tinyusb/src/common/tusb_fifo.o
 OBJS += tinyusb/src/class/msc/msc_device.o tinyusb/src/class/midi/midi_device.o
 OBJS += tinyusb/src/class/cdc/cdc_device.o tinyusb/src/class/hid/hid_device.o
+OBJS += tinyusb/src/class/dfu/dfu_rt_device.o
 OBJS += dcd_tntusb.o usb_descriptors.o hexdump.o flash.o
 OBJS += fatfs/source/ff.o fatfs/source/ffunicode.o loadapp.o elfload/elfload.o
 OBJS += elfload/elfreloc_riscv.o lodepng.o bgnd.o tileset-default.o

--- a/soc/ipl/main.c
+++ b/soc/ipl/main.c
@@ -414,3 +414,23 @@ void tud_cdc_rx_cb(uint8_t itf) {
 	(void)itf;
 }
 
+// Invoked on DFU_DETACH request to reboot to the bootloader
+void tud_dfu_rt_reboot_to_dfu(void)
+{
+	volatile uint32_t *psram  = (volatile uint32_t *)(MACH_RAM_START);
+	volatile uint32_t *reboot = (volatile uint32_t *)(MISC_OFFSET + MISC_FLASH_SEL_REG);
+
+	// Debug
+	printf("REBOOT\n");
+
+	// Set MAGIC value in PSRAM
+	psram[0] = 0x46464444;
+	psram[1] = 0x21215555;
+	cache_flush((void*)&psram[0], (void*)&psram[2]);
+
+	// Reboot
+	*reboot = 0xD0F1A500;
+
+	// Wait indefinitely
+	while (1);
+}

--- a/soc/ipl/tusb_config.h
+++ b/soc/ipl/tusb_config.h
@@ -73,6 +73,7 @@
 #define CFG_TUD_CDC                 1
 #define CFG_TUD_MSC                 1
 #define CFG_TUD_HID                 0
+#define CFG_TUD_DFU_RT              1
 
 #define CFG_TUD_MIDI                0
 #define CFG_TUD_CUSTOM_CLASS        0

--- a/soc/ipl/usb_descriptors.c
+++ b/soc/ipl/usb_descriptors.c
@@ -97,12 +97,16 @@ enum
   ITF_NUM_HID,
 #endif
 
+#if CFG_TUD_DFU_RT
+  ITF_NUM_DFU_RT,
+#endif
+
   ITF_NUM_TOTAL
 };
 
 enum
 {
-  CONFIG_TOTAL_LEN = TUD_CONFIG_DESC_LEN + CFG_TUD_CDC*TUD_CDC_DESC_LEN + CFG_TUD_MSC*TUD_MSC_DESC_LEN + CFG_TUD_HID*TUD_HID_DESC_LEN
+  CONFIG_TOTAL_LEN = TUD_CONFIG_DESC_LEN + CFG_TUD_CDC*TUD_CDC_DESC_LEN + CFG_TUD_MSC*TUD_MSC_DESC_LEN + CFG_TUD_HID*TUD_HID_DESC_LEN + CFG_TUD_DFU_RT*TUD_DFU_RT_DESC_LEN
 };
 
 #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
@@ -132,7 +136,12 @@ uint8_t const desc_configuration[] =
 
 #if CFG_TUD_HID
   // Interface number, string index, protocol, report descriptor len, EP In address, size & polling interval
-  TUD_HID_DESCRIPTOR(ITF_NUM_HID, 6, HID_PROTOCOL_NONE, sizeof(desc_hid_report), 0x84, 16, 10)
+  TUD_HID_DESCRIPTOR(ITF_NUM_HID, 6, HID_PROTOCOL_NONE, sizeof(desc_hid_report), 0x84, 16, 10),
+#endif
+
+#if CFG_TUD_DFU_RT
+  // Interface number, string index, attributes, detach timeout, transfer size */
+  TUD_DFU_RT_DESCRIPTOR(ITF_NUM_DFU_RT, 7, 0x0d, 1000, 4096),
 #endif
 };
 
@@ -162,7 +171,8 @@ char const* string_desc_arr [] =
   "0000000000000000",            // 3: Serials, should use chip ID
   "TinyUSB CDC",                 // 4: CDC Interface
   "TinyUSB MSC",                 // 5: MSC Interface
-  "TinyUSB HID"                  // 6: HID
+  "TinyUSB HID",                 // 6: HID
+  "DFU Runtime interface",       // 7: DFU Runtime
 };
 
 static uint16_t _desc_str[32];

--- a/soc/ipl/usb_descriptors.c
+++ b/soc/ipl/usb_descriptors.c
@@ -24,13 +24,14 @@
  */
 
 #include "tusb.h"
+#include "usb_descriptors.h"
 
 //------------- Device Descriptors -------------//
 tusb_desc_device_t const desc_device =
 {
     .bLength            = sizeof(tusb_desc_device_t),
     .bDescriptorType    = TUSB_DESC_DEVICE,
-    .bcdUSB             = 0x0200,
+    .bcdUSB             = 0x0201,
 
   #if CFG_TUD_CDC
     // Use Interface Association Descriptor (IAD) for CDC
@@ -48,7 +49,7 @@ tusb_desc_device_t const desc_device =
 
     .idVendor           = 0x1d50,
     .idProduct          = 0x614a,
-    .bcdDevice          = 0x0100,
+    .bcdDevice          = 0x0102,
 
     .iManufacturer      = 0x01,
     .iProduct           = 0x02,
@@ -160,6 +161,49 @@ uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
   (void) index; // for multiple configurations
   return desc_configuration;
 }
+
+
+//------------- BOS Descriptor -------------//
+
+#define BOS_TOTAL_LEN      (TUD_BOS_DESC_LEN + TUD_BOS_MICROSOFT_OS_DESC_LEN)
+
+#define MS_OS_20_DESC_LEN  0x2E
+
+// BOS Descriptor
+uint8_t const desc_bos[] =
+{
+  // total length, number of device caps
+  TUD_BOS_DESCRIPTOR(BOS_TOTAL_LEN, 1),
+
+  // Microsoft OS 2.0 descriptor
+  TUD_BOS_MS_OS_20_DESCRIPTOR(MS_OS_20_DESC_LEN, VENDOR_REQUEST_MICROSOFT),
+};
+
+uint8_t const * tud_descriptor_bos_cb(void)
+{
+  return desc_bos;
+}
+
+
+uint8_t const desc_ms_os_20[] =
+{
+  // Set header: length, type, windows version, total length
+  U16_TO_U8S_LE(0x000A), U16_TO_U8S_LE(MS_OS_20_SET_HEADER_DESCRIPTOR), U32_TO_U8S_LE(0x06030000), U16_TO_U8S_LE(MS_OS_20_DESC_LEN),
+
+  // Configuration subset header: length, type, configuration index, reserved, configuration total length
+  U16_TO_U8S_LE(0x0008), U16_TO_U8S_LE(MS_OS_20_SUBSET_HEADER_CONFIGURATION), 0, 0, U16_TO_U8S_LE(MS_OS_20_DESC_LEN-0x0A),
+
+  // Function Subset header: length, type, first interface, reserved, subset length
+  U16_TO_U8S_LE(0x0008), U16_TO_U8S_LE(MS_OS_20_SUBSET_HEADER_FUNCTION), ITF_NUM_DFU_RT, 0, U16_TO_U8S_LE(MS_OS_20_DESC_LEN-0x0A-0x08),
+
+  // MS OS 2.0 Compatible ID descriptor: length, type, compatible ID, sub compatible ID
+  U16_TO_U8S_LE(0x0014), U16_TO_U8S_LE(MS_OS_20_FEATURE_COMPATBLE_ID), 'W', 'I', 'N', 'U', 'S', 'B', 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sub-compatible
+};
+
+TU_VERIFY_STATIC(sizeof(desc_ms_os_20) == MS_OS_20_DESC_LEN, "Incorrect size");
+
+
 //------------- String Descriptors -------------//
 
 // array of pointer to string descriptors

--- a/soc/ipl/usb_descriptors.h
+++ b/soc/ipl/usb_descriptors.h
@@ -1,0 +1,35 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef USB_DESCRIPTORS_H_
+#define USB_DESCRIPTORS_H_
+
+enum {
+  VENDOR_REQUEST_MICROSOFT = 1,
+};
+
+extern uint8_t const desc_ms_os_20[];
+
+#endif /* USB_DESCRIPTORS_H_ */


### PR DESCRIPTION
This allows the IPL to force a reboot to the DFU bootloader through USB to make for completely transparent operations. (dfu-util can reboot from IPL to bootloader, flash SoC / IPL, then reboot again to application mode, all without user intervention)

It also contains proper WCID support for Windows so that all the DFU interfaces are bound to WINUSB to allow dfu-util to access them without requiring the user to do anything beside plugging in the badge.