### PR TITLE
Fix verilog warnings

### DIFF
--- a/soc/video/Makefile
+++ b/soc/video/Makefile
@@ -1,6 +1,6 @@
 SRC := ram_dp_24x2048_sim.v video_mem.v vid_linerenderer.v vid.v ../qpi_cache/qpimem_dma_rdr.v
 SRC += vid_palettemem_sim.v vid_tilemapmem_sim.v vid_tilemem_sim.v vgapal.c ../mul_18x18_sim.v
-SRC += vid_spriteeng.v vid_sprite_linebuf_sim.v vid_spritemem_sim.v
+SRC += vid_spriteeng.v vid_sprite_linebuf_sim.v vid_spritemem_sim.v video_alphamixer.v
 
 SRC_SIM := video_renderer.cpp verilator_main.cpp verilator_options.cpp verilator_setup.cpp
 

--- a/soc/video/vid_linerenderer.v
+++ b/soc/video/vid_linerenderer.v
@@ -625,7 +625,7 @@ always @(posedge clk) begin
 						//next line
 						write_vid_addr_next[19:9] <= write_vid_addr_next[19:9] + 'h1;
 						write_vid_addr_next[8:0] <= 0;
-						dma_start_addr <= dma_start_addr + (fb_is_8bit?pitch:pitch/2);
+						dma_start_addr <= dma_start_addr + (fb_is_8bit?pitch:pitch[15:1]);
 						dma_run <= 0;
 						tilea_x <= tilea_linestart_x;
 						tilea_y <= tilea_linestart_y;

--- a/soc/video/vid_linerenderer.v
+++ b/soc/video/vid_linerenderer.v
@@ -230,7 +230,7 @@ always @(*) begin
 		end else if (addr[5:2]==REG_SEL_BGNDCOL) begin
 			dout = bgnd_color;
 		end else if (addr[5:2]==REG_SEL_SPRITE_OFF) begin
-			dout = {4'h0, sprite_yoff, 4'h0, sprite_xoff};
+			dout = {3'h0, sprite_yoff, 3'h0, sprite_xoff};
 		end
 	end else if (addr[16:13]=='h1) begin
 		cpu_sel_palette = 1;

--- a/soc/video/vid_spriteeng.v
+++ b/soc/video/vid_spriteeng.v
@@ -211,11 +211,11 @@ size_to_d_lookup_rom reciproc_rom_y (
 
 wire [12:0] virt_ypos;
 wire [12:0] virt_xpos;
-assign virt_ypos = vid_ypos + offy;
-assign virt_xpos = vid_xpos + offx;
+assign virt_ypos = {4'b0, vid_ypos} + offy;
+assign virt_xpos = {4'b0, vid_xpos} + offx;
 
 wire [17:0] gfx_ypos; //ypos within the scaled output tile
-assign gfx_ypos = {7'h0, virt_ypos} - {4'h0, spritemem_data[2][29:16]}; //stage 4
+assign gfx_ypos = {5'h0, virt_ypos} - {4'h0, spritemem_data[2][29:16]}; //stage 4
 wire [35:0] tile_ypos_multiplied;
 reg [15:0] reciproc_y_out_reg; //for stage 4
 
@@ -223,7 +223,7 @@ reg [15:0] reciproc_y_out_reg; //for stage 4
 //Input is anywhere 0-255 on gfx_ypos, 65536-0 on tile_ypos_multiplied.
 //Multiplied, this gives a number from 0 to 16K.
 mul_18x18 mul_ypos(
-	.a(reciproc_y_out_reg),
+	.a({2'b0, reciproc_y_out_reg}),
 	.b(gfx_ypos),
 	.dout(tile_ypos_multiplied)
 );
@@ -282,7 +282,7 @@ always @(posedge clk) begin
 			spritemem_data[4] <= spritemem_data[3]; //stage 6
 			reciproc_y_out_reg <= reciproc_y_out; //stage 4
 			tile_ypos_reg <= tile_ypos;
-			if (spritemem_data[2][29:16]<=virt_ypos && !tile_ypos_ovf && spritemem_data[2][39:32]!=0 && spritemem_data[2][47:40]!=0) begin
+			if (spritemem_data[2][28:16]<=virt_ypos && !tile_ypos_ovf && spritemem_data[2][39:32]!=0 && spritemem_data[2][47:40]!=0) begin
 				drawable_ready <= !line_done;
 			end
 		end
@@ -323,8 +323,8 @@ wire [35:0] tile_xpos_multiplied;
 //Input is anywhere 0-255 on gfx_ypos, 65536-0 on tile_ypos_multiplied.
 //Multiplied, this gives a number from 0 to 16K.
 mul_18x18 mul_xpos(
-	.a(reciproc_x_out_reg),
-	.b(dspr_xoff),
+	.a({2'b0, reciproc_x_out_reg}),
+	.b({4'b0, dspr_xoff}),
 	.dout(tile_xpos_multiplied)
 );
 wire [3:0] tile_xpos;
@@ -387,7 +387,7 @@ always @(posedge clk) begin
 			end
 			if (tilemem_has_data) begin
 				if (tilemem_data != 0) begin
-					lb_din <= tilemem_data + dspr_pal_sel*4;
+					lb_din <= {5'b0, tilemem_data} + ({dspr_pal_sel, 2'b00});
 					lb_wr <= 1;
 				end
 			end

--- a/soc/video/video_alphamixer.v
+++ b/soc/video/video_alphamixer.v
@@ -44,7 +44,7 @@ always @(*) begin
 		alpha_a = 'h100;
 		alpha_b = 0;
 	end else begin
-		alpha_a = rate;
+		alpha_a = {1'0, rate};
 		alpha_b = ('h100 - rate);
 	end
 end
@@ -53,12 +53,12 @@ genvar i;
 for (i=0; i<4; i++) begin
 	mul_18x18 mult_s (
 		.a({10'h0, in_a[i*8+:8]}),
-		.b({10'h0, alpha_a}),
+		.b({9'h0, alpha_a}),
 		.dout(mulr_out_a[i])
 	);
 	mul_18x18 mult_d (
 		.a({10'h0, in_b[i*8+:8]}),
-		.b({10'h0, alpha_b}),
+		.b({9'h0, alpha_b}),
 		.dout(mulr_out_b[i])
 	);
 	assign out[i*8+:8] = mulr_out_a[i][15:8]+mulr_out_b[i][15:8];


### PR DESCRIPTION
Fix warnings given by verilator when compiling soc/video code.

I found one small bug doing this: in vid_linenderer.v, the sprite offset register y offset would have been shifted left by 1 bit. 
