### PR TITLE
vid_linerenderer.v: Fix bug reading sprite offset register

### DIFF
--- a/soc/video/vid_linerenderer.v
+++ b/soc/video/vid_linerenderer.v
@@ -229,7 +229,7 @@ always @(*) begin
 		end else if (addr[5:2]==REG_SEL_BGNDCOL) begin
 			dout = bgnd_color;
 		end else if (addr[5:2]==REG_SEL_SPRITE_OFF) begin
-			dout = {4'h0, sprite_yoff, 4'h0, sprite_xoff};
+			dout = {3'h0, sprite_yoff, 3'h0, sprite_xoff};
 		end
 	end else if (addr[16:13]=='h1) begin
 		cpu_sel_palette = 1;


### PR DESCRIPTION
Remove excess padding from return value when reading sprite offset register.

4 bits of padding were being added between the X&Y offsets, but since each
value is 13 bits long, there should be only 3 bits of padding.