### PR TITLE
Skip autoexec when START is held

### DIFF
--- a/soc/ipl/main.c
+++ b/soc/ipl/main.c
@@ -445,8 +445,8 @@ void main() {
 	SYNTHREG(0x60) = 0x00352400;	
 	SYNTHREG(0x70) = 0x00453000;	
     
-	//Skip autoexec when user is holding down START
-	if(!(MISC_REG(MISC_BTN_REG)&BUTTON_START)) {
+	//Skip autoexec when user is holding down the designated bypass key
+	if(!(MISC_REG(MISC_BTN_REG)&BUTTON_B)) {
 		//See if there's an autoexec.elf we can run.
 		const char *autoexec;
 		if (booted_from_cartridge()) {

--- a/soc/ipl/main.c
+++ b/soc/ipl/main.c
@@ -445,24 +445,26 @@ void main() {
 	SYNTHREG(0x60) = 0x00352400;	
 	SYNTHREG(0x70) = 0x00453000;	
     
-
-	//See if there's an autoexec.elf we can run.
-	const char *autoexec;
-	if (booted_from_cartridge()) {
-		autoexec="cart:autoexec.elf";
-	} else {
-		autoexec="int:autoexec.elf";
-	}
-	FILE *f=fopen(autoexec, "r");
-	if (f!=NULL) {
-		fclose(f);
-		printf("Found %s. Executing\n", autoexec);
-		load_tiles();
-		usb_msc_off();
-		start_app(autoexec);
-		printf("%s done.\n", autoexec);
-	} else {
-		printf("No %s found; not running\n", autoexec);
+	//Skip autoexec when user is holding down START
+	if(!(MISC_REG(MISC_BTN_REG)&BUTTON_START)) {
+		//See if there's an autoexec.elf we can run.
+		const char *autoexec;
+		if (booted_from_cartridge()) {
+			autoexec="cart:autoexec.elf";
+		} else {
+			autoexec="int:autoexec.elf";
+		}
+		FILE *f=fopen(autoexec, "r");
+		if (f!=NULL) {
+			fclose(f);
+			printf("Found %s. Executing\n", autoexec);
+			load_tiles();
+			usb_msc_off();
+			start_app(autoexec);
+			printf("%s done.\n", autoexec);
+		} else {
+			printf("No %s found; not running\n", autoexec);
+		}
 	}
 
 	while(1) {


### PR DESCRIPTION
When the user wants to skip autoexec to boot faster, they can now hold down START to bypass autoexec.

Also allows the user to bypass a bad autoexec.elf, which resolves issue #62 