### PR TITLE
sdk.mk: fix path to toolchain-settings.mk

### DIFF
--- a/apps-sdk/sdk.mk
+++ b/apps-sdk/sdk.mk
@@ -1,7 +1,7 @@
 #Include local settings for entire project, if they exist
 -include ../local-settings.mk
 
-include ../toolchain-settings.mk
+include $(APPSSDK_DIR)/../toolchain-settings.mk
 
 #Name of what we're trying to build.
 TARGET_ELF := $(APPNAME).elf


### PR DESCRIPTION
Locate toolchain-settings.mk file when building on path outside of repo.

There was a bug where a make outside the repo would fail, even if APPSSDK_DIR was set properly:
```
$ make
/home/alang/hadbadge/hadbadge2019_fpgasoc/apps-sdk/sdk.mk:4: ../toolchain-settings.mk: No such file or directory
make: *** No rule to make target '../toolchain-settings.mk'.  Stop.
```
