### PR TITLE
soc/Makefile: fix for WSL and Linux Tools

### DIFF
--- a/soc/Makefile
+++ b/soc/Makefile
@@ -152,7 +152,10 @@ ifeq ($(OS),Windows_NT)
 EXE:=.exe
 endif
 ifneq ("$(WSL_DISTRO_NAME)","")
-EXE:=.exe
+	# if using Windows Subsystem for Linux, and yosys not found, try adding .exe
+	ifeq (, $(shell which yosys))
+		EXE:=.exe
+ 	endif
 endif
 
 #Image read mode: qspi, dual-spi, fast-read


### PR DESCRIPTION
Under WSL, allow SoC to be built with either Windows or Linux tools. Tested with both toolchains.

(Sorry for the multiple PRs - it turns out that make locates yosys using a different code than it does for the gcc toolchain, and I didn't notice until I went to rebuild the SoC,.)