### PR TITLE
Decreased conditions for amix_out_cur to amix_out assignment.

### DIFF
--- a/soc/video/vid_linerenderer.v
+++ b/soc/video/vid_linerenderer.v
@@ -694,6 +694,9 @@ always @(posedge clk) begin
 		dma_do_read <= 0;
 		vid_wen <= 0;
 
+		//Latch current alphamixer output.
+		alphamixer_out <= alphamixer_out_cur;
+
 		//Line renderer proper statemachine.
 		if (write_vid_addr[19:9]>=320) begin
 			//We're finished with this frame. Wait until the video generator starts drawing the next frame.
@@ -728,7 +731,6 @@ always @(posedge clk) begin
 					dma_do_read <= 1;
 				end
 
-				alphamixer_out <= alphamixer_out_cur;
 				cycle <= cycle + 1;
 				if (cycle==0) begin
 					if (fb_is_8bit) begin


### PR DESCRIPTION
The alphamixer_out <= alphamixer_out_cur can be done outside of the
state machine as it is an output dependent on the vid_wen bit. It very
slightly improves the timing for clk48m from 49.36 MHz to 49.74 MHz.

I will be adding another combinatorial step in that output path as part
of the workshop. In that case this change make a huge timing difference
fail vs pass. Having this minor change will make the workshop bit less
convoluted and easier to follow.

Of course I might be missing something and this is a terrible idea. Please let me know. :D 