### PR TITLE
audio: Fix loading of wait delay counter if it's first command in FIFO

### DIFF
--- a/soc/audio/audio_wb.v
+++ b/soc/audio/audio_wb.v
@@ -337,7 +337,7 @@ module audio_wb (
 
 	// Delay counter
 	always @(posedge clk)
-		delay_ld <= cf_ren;
+		delay_ld <= cf_ren | cf_empty;
 
 	always @(posedge clk)
 		delay_cnt <= delay_ld ? { 1'b0, cf_rdata[15:0] } : (delay_cnt - (stb_synth ? 1 : 0));


### PR DESCRIPTION
ATM if the command fifo goes empty and then the first new command to be
pushed is a wait command, it will load a random value ...

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>