### PR TITLE
Remove mentions of the tinyprog / old flash process

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "soc/picorv32"]
 	path = soc/picorv32
 	url = https://github.com/cliffordwolf/picorv32.git
-[submodule "TinyFPGA-Bootloader"]
-	path = TinyFPGA-Bootloader
-	url = https://github.com/Spritetm/hadbadge2019_tinyfpgabootloader.git
 [submodule "soc/app/tinyusb"]
 	path = soc/ipl/tinyusb
 	url = https://github.com/hathach/tinyusb.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,6 @@ ARG toolchain='https://github.com/xobs/ecp5-toolchain/releases/download/v1.6.2/e
 # Add packages needed to run the toolchain and badge utilities
 RUN install_packages wget ca-certificates build-essential bsdmainutils python3 python3-pip
 
-# Install Python setuptools and wheel, needed for tinyprog
-RUN pip3 install setuptools wheel
-RUN pip3 install tinyprog
-
 # Fetch, rename, and extract toolchain package
 WORKDIR /
 RUN wget $toolchain -O toolchain.tar.gz

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,18 +6,6 @@ This document is only for tracking items out of our control to fix, such as prob
 
 ---
 
-Symptom: tinyprog fails to launch with SyntaxError in more_itertools module
-
-file more.py declaration def _collate(*iterables, key=lambda a: a, reverse=False):
-
-Explanation: tinyprog is a Python 2 program, but more_itertools has dropped support for Python 2 so running latest version raises SyntaxError.
-
-Solution: Make sure tinyprog runs with more_itertools version 5, the final version to support Python 2. ([source](https://pypi.org/project/more-itertools/))
-
-Note: Will become moot if the switch to DFU-based bootloader is successful.
-
----
-
 Symptom: nextpnr-ecp5 fails to launch with file not found error for libpython3.7m.so.1.0
 
 Solution: Install Python 3 development libraries. On Debian (& derivatives) this can be done by running: sudo apt-get install libpython3.7-dev

--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ From here, you can start hacking:
 Repo directory structure
 ========================
 
-- TinyFPGA-Bootloader contains the boot loader that can be used to re-write 
-the flash of the badge over USB. (Used to upload new config without JTAG.) 
-
 - blink contains a trivial blinker project, useful to make sure your setup 
 works. 
 

--- a/blink/Makefile
+++ b/blink/Makefile
@@ -7,7 +7,7 @@ FLASH_MODE=qspi
 FLASH_FREQ=38.8 #MHz
 
 
-all: $(PROJ).svf flash
+all: $(PROJ).svf dfu_flash
 
 %.json: %.v
 	yosys -p "synth_ecp5 -json $@" $<
@@ -26,9 +26,6 @@ prog: $(PROJ).svf
 
 clean:
 	rm -f $(PROJ).json $(PROJ).svf $(PROJ).bit $(PROJ)_out.config
-
-flash: $(PROJ).bit
-	tinyprog -p $(PROJ).bit -a 0x180000
 
 dfu_flash: $(PROJ).bit
 	dfu-util$(EXE) -d 1d50:614a,1d50:614b -a 2 -R -D $(PROJ).bit

--- a/soc/Makefile
+++ b/soc/Makefile
@@ -190,9 +190,6 @@ $(PROJ).json $(PROJ).blif: $(SRC) $(SRC_SYNTH) $(EXTRA_DEPEND)
 prog: $(PROJ).svf
 	openocd -f ../openocd.cfg -c "init; svf  $<; exit"
 
-flash: $(PROJ).bit
-	tinyprog -p $(PROJ).bit -a 0x180000
-
 dfu_flash: $(PROJ).bit
 	dfu-util$(EXE) -d 1d50:614a,1d50:614b -a 0 -R -D $<
 

--- a/soc/ipl/Makefile
+++ b/soc/ipl/Makefile
@@ -74,9 +74,6 @@ prog: $(TARGET_SVF)
 $(TARGET_SVF): $(TARGET_BIN)
 	../jtagload/jtagload < $(TARGET_BIN) > $(TARGET_SVF)
 
-flash: $(TARGET_BIN)
-	tinyprog -p $(TARGET_BIN) -a 0x300000
-
 dfu_flash: $(TARGET_BIN)
 	dfu-util$(EXE) -d 1d50:614a,1d50:614b -a 1 -R -D $<
 


### PR DESCRIPTION
This won't be used on production badge and reading online seems to confuse
some people about what they need to work with the badge, so remove it
from the repo.

The actual code still remains in the separate repo obviously.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>