### PR TITLE
Working around weird make mkdir issue on Mac OS X

### DIFF
--- a/apps-sdk/sdk.mk
+++ b/apps-sdk/sdk.mk
@@ -69,12 +69,12 @@ endif
 define build_template
 $(1)/%.o: $(2)/%.c $(1)/%.d
 	$$(vecho) CC $$(notdir $$<)
-	$$(Q)mkdir -p $(1)
+	$$(Q)mkdir -p $$(dir $$@)
 	$$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c -o $$@ $$<
 
 $(1)/%.o: $(2)/%.S $(1)/%.d
 	$$(vecho) CC $$(notdir $$<)
-	$$(Q)mkdir -p $(1)
+	$$(Q)mkdir -p $$(dir $$@)
 	$$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c -o $$@ $$<
 endef
 


### PR DESCRIPTION
For some reason, $(1) was always returning the build directory and $(2) would
always be the app directory inside the build_template recipe. This caused the
mkdir to try and make ./build even when it needed to make ./build/subdir.

This is fixed, or at least made to be more consistent by using the directory of
the output file rather than the templated variable. There may be a different
fix but I couldn't figure it out. The foreach loop does seem to pass in the
correct path to the template function.