### PR TITLE
Add libusb-1.0 to docker image, clarify USB hardware limitations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM bitnami/minideb:latest
 ARG toolchain='https://github.com/xobs/ecp5-toolchain/releases/download/v1.6.2/ecp5-toolchain-linux_x86_64-v1.6.2.tar.gz'
 
 # Add packages needed to run the toolchain and badge utilities
-RUN install_packages wget ca-certificates build-essential bsdmainutils python3 python3-pip
+RUN install_packages wget ca-certificates build-essential bsdmainutils libusb-1.0-0
 
 # Fetch, rename, and extract toolchain package
 WORKDIR /

--- a/doc/toolchain-docker.md
+++ b/doc/toolchain-docker.md
@@ -3,7 +3,7 @@
 ### Why?
 Installing these tools in a Docker image means you don't have to install them on your local machine, which is probably weird because of all the other toolchains you've indiscriminately installed before. Stop the madness and keep things organized into useful containers. And compared to a virtual machine, you can edit your source files and do version control on your local machine, no need to worry about transferring files to a VM or sharing folders.
 - Pros: Likely to work on any computer that runs Docker, no conflicts with existing setup. On macOS Catalina, this removes a major source of pain approving all the toolchain binaries before running.
-- Cons: Not as easy to reach in and tweak the toolchain itself; if you need to do that, consider moving up to a full virtual machine.
+- Cons: Not as easy to reach in and tweak the toolchain itself; if you need to do that, consider moving up to a full virtual machine. Also, if you're attempting to flash the bootloader, soc, ipl, or anything else that uses `dfu-util`, it's unlikely to work except on a Linux host system due to limitations on Mac and Windows passthrough of USB devices. This may require installing a local version of `dfu-util`.
 
 ### Building the image
 While in this directory (`hadbadge2019_fpgasoc`) run the following command to create a "hadbadge" image with minimal Debian + ECP5 toolchain:
@@ -14,7 +14,7 @@ The badge codebase requires access to parent and peer directories when compiling
 
 The tricky parts are wrapped in `badge_container.sh` which is a script to extract the top level and current PWD. The script requires `git` in order to determine the top-level directory of the repository we're in.
 
-The `docker run` command line uses privileged mode, which should give it access to USB devices for flashing (not tested due to lack of access to hardware at the moment). It will launch the `hadbadge` image plus whatever commands you want to run inside the container. The command line above is made available in the parent directory for convenience, so the typical use case looks like this:
+The `docker run` command line uses privileged mode, which should give it access to USB devices for flashing (not tested due to lack of access to hardware at the moment, and likely to work only on Linux or when running inside a Linux VM with specific USB devices granted to the VM). It will launch the `hadbadge` image plus whatever commands you want to run inside the container. The command line above is made available in the parent directory for convenience, so the typical use case looks like this:
 - Start in the `hadbadge2019_fpgasoc` directory
 - `cd app-helloworld`
 - `../badge_container.sh make`


### PR DESCRIPTION
Libusb was needed for dfu-util, and the Docker implementation for USB passthrough only really works on Linux hosts. Documentation updated to adjust expectations. The container still helps on Mac for setting up a clean build environment, if dfu-util can be set up locally for bootloader and soc flash operations. RISC-V ELF binaries should still work as usual with mass storage transfer.