### PR TITLE
sdk: Align all input sections to .data to 4 bytes

### DIFF
--- a/apps-sdk/gloss/ldscript.ld
+++ b/apps-sdk/gloss/ldscript.ld
@@ -29,7 +29,7 @@ SECTIONS {
 		*(.text);
 		*(.text.*);
 	} > ram
-	.data : {
+	.data : SUBALIGN(4) {
 		. = ALIGN(4);
 		*(.rodata);
 		*(.rodata.*);


### PR DESCRIPTION
This is the only solution I found to force every binary file included
to be aligned to 32 bits. My attempts to set the alignement inside
the .o generated by arguments to objcopy didn't yield anything.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>