### PR TITLE
lcdiface: add backlight PWM

### DIFF
--- a/soc/ipl/gloss/mach_defines.h
+++ b/soc/ipl/gloss/mach_defines.h
@@ -172,6 +172,10 @@
 /** Command that is sent before a new frame is transmitted. */
 #define LCD_FB_STARTCMD 0x10
 
+/** Backlight PWM width control. Lower 16 bits control how much backlight to give, 
+    if LCD_CONTROL_BLEN set in LCD_CONTROL_REG. */
+#define LCD_BL_LEVEL_REG 0x14
+
 /* -------------- GFX subsystem defines --------------------- */
 
 /** 


### PR DESCRIPTION
Adds a backlight PWM and register to control it. Backlight frequency is
approximately 200Hz.

Not tested on actual hardware, but works in Verilator.

See issue #60 