### PR TITLE
Animate IPL text with trig functions from FastLED

### DIFF
--- a/soc/ipl/main.c
+++ b/soc/ipl/main.c
@@ -324,8 +324,6 @@ int show_main_menu(char *app_name, int *ret_flags) {
 						"or insert an USB cable to modify the files on the flash. Have fun!"
 						"                       ";
 	int scrpos=0;
-	int usb_tasks_count=0; // Count how much time per menu frame is available for USB tasks
-	int usb_tasks_output_frames=0;
 
 	//Generate copper list to transform the center of the screen into a barrel-ish
 	//shape for tile layer B.
@@ -459,15 +457,7 @@ int show_main_menu(char *app_name, int *ret_flags) {
 		do {
 			cdc_task();
 			tud_task();
-			usb_tasks_count++;
 		} while (GFX_REG(GFX_VBLCTR_REG) <= cur_vbl_ctr+1); //we run at 30fps
-		if (usb_tasks_output_frames >= 100) {
-			printf("%d USB tasks over %d frames\n", usb_tasks_count,usb_tasks_output_frames);
-			usb_tasks_count = 0;
-			usb_tasks_output_frames = 0;
-		} else {
-			usb_tasks_output_frames++;
-		}
 		old_btn=btn;
 	}
 	


### PR DESCRIPTION
While IPL main menu is running, any CPU time spent calculating our pretty animation is time not available for handling USB mass storage work. This slows down things like mounting USB volume and file copy operations. By using the less accurate (but much faster!) 8-bit trig functions from the [FastLED library](https://github.com/FastLED/FastLED), we have much faster USB while still keeping our pretty animations.