### PR TITLE
Fixed a gloss make build error

### DIFF
--- a/soc/ipl/Makefile
+++ b/soc/ipl/Makefile
@@ -84,7 +84,7 @@ gdb: $(TARGET_ELF)
 	$(GDB) -b 115200 -ex "target remote /dev/ttyUSB0" $(APPNAME).elf
 
 .PHONY: gloss/libgloss.a
-gloss/libgloss.a: gloss/
+gloss/libgloss.a: gloss
 	$(MAKE) -C gloss
 
 include $(wildcard $(DEPFILES))


### PR DESCRIPTION
Removed "/" at the end of "gloss/libgloss.a: gloss/" to make it build on Windows. Requires testing on other platforms. Thanks @ianjfrosst for the fix!