### PR TITLE
Update nyan to stop sound playback on exit

### DIFF
--- a/app-nyan/libmidi.c
+++ b/app-nyan/libmidi.c
@@ -1,15 +1,15 @@
 
 #include "libmidi.h"
 
-uint16_t midi_play_song(uint16_t songArray[][3], uint16_t songLength, uint32_t clocksPerClick){
-	static uint16_t song_step     = 0;
-	static uint8_t  gates         = 0;
-	static uint32_t last_time     = 0;
-	static uint32_t time_interval = 0;
-	static uint32_t delta         = 0;
-	static uint32_t voice         = 0;
-	static uint32_t note          = 255;
+static uint16_t song_step     = 0;
+static uint8_t  gates         = 0;
+static uint32_t last_time     = 0;
+static uint32_t time_interval = 0;
+static uint32_t delta         = 0;
+static uint32_t voice         = 0;
+static uint32_t note          = 255;
 
+uint16_t midi_play_song(uint16_t songArray[][3], uint16_t songLength, uint32_t clocksPerClick){
 	// Update only if enough time has elapsed
 	if (time() - last_time >= time_interval ){
 		last_time = time();
@@ -39,4 +39,15 @@ uint16_t midi_play_song(uint16_t songArray[][3], uint16_t songLength, uint32_t c
 		song_step++;
 	}
 	return song_step;
+}
+
+void midi_reset(void) {
+	song_step     = 0;
+	gates         = 0;
+	last_time     = 0;
+	time_interval = 0;
+	delta         = 0;
+	voice         = 0;
+	note          = 255;
+	synth_all_off();
 }

--- a/app-nyan/libmidi.h
+++ b/app-nyan/libmidi.h
@@ -27,5 +27,7 @@
 // Returns which step in the song just played
 uint16_t midi_play_song(uint16_t songArray[][3], uint16_t length, uint32_t clocksPerClick);
 
-
+// stops music playback and resets to initial conditions allowing changing
+// to a new song
+void midi_reset(void);
 

--- a/app-nyan/main.c
+++ b/app-nyan/main.c
@@ -95,13 +95,10 @@ void main(int argc, char **argv) {
 			}
 		}
 
-
 		// Add in music:
-
-        midi_play_song(nyan, sizeof(nyan)/sizeof(uint16_t)/3 , BPM(120));
-
+		midi_play_song(nyan, sizeof(nyan)/sizeof(uint16_t)/3 , BPM(120));
 
 		while (GFX_REG(GFX_VBLCTR_REG) <= cur_vbl_ctr);
-
 	}
+	midi_reset();
 }


### PR DESCRIPTION
Added midi_reset() to libmidi that resets library state
to allow playing another song and ends current audio playback.
Use that on exit from nyancat