### PR TITLE
fire-app: fix random seed line generation

### DIFF
--- a/app-fire/main.c
+++ b/app-fire/main.c
@@ -46,7 +46,7 @@ void __render_fire(void) {
 	/* draw randomized fire seed row */
 	uint32_t rnd;
 	for (int x = 0; x < FB_WIDTH; x++) {
-		if ((x & 32) == 0) {
+		if ((x & 31) == 0) {
 			rnd = MISC_REG(MISC_RNG_REG);
 		}
 		if (rnd & 0x00000001) {


### PR DESCRIPTION
The optimization using the most out of the random word generator runs "off the end"? Resulted in a consistent `0` before starting to use a newly generated random value. Generate a new random value one bit earlier.