### PR TITLE
fix idle bug and formally verify

### DIFF
--- a/soc/arbiter.sby
+++ b/soc/arbiter.sby
@@ -1,0 +1,14 @@
+[options]
+mode prove 
+append 5
+
+[engines]
+smtbmc
+
+[script]
+read_verilog -formal arbiter.v
+prep -top arbiter
+
+[files]
+arbiter.v
+


### PR DESCRIPTION
I took a look at formally verifying the arbiter. I thought I found a bug (idle is never set to 1), but in fact it doesn't change the operation or throughput of the arbiter.

However, I have set it to 1 here, so that hold is released and idle becomes 1 as I think that is your intent. Might fix verilator warning too?