### PR TITLE
Remove (now) duplicate GFXSPRITES declaration

### DIFF
--- a/app-autoexec/main.c
+++ b/app-autoexec/main.c
@@ -71,8 +71,6 @@ extern volatile uint32_t MISC[];
 extern volatile uint32_t GFXREG[];
 #define GFX_REG(i) GFXREG[(i)/4]
 
-uint32_t *GFXSPRITES = (uint32_t *)0x5000C000;
-
 //Used to debounce buttons
 #define BUTTON_READ_DELAY		15
 

--- a/app-deepnote/main.c
+++ b/app-deepnote/main.c
@@ -51,8 +51,6 @@ extern volatile uint32_t MISC[];
 extern volatile uint32_t GFXREG[];
 #define GFX_REG(i) GFXREG[(i)/4]
 
-uint32_t *GFXSPRITES = (uint32_t *)0x5000C000;
-
 /////////////////////////////////////////////////////////////////////////////
 //
 //	Constants for tile positions and offsets

--- a/app-flappy/main.c
+++ b/app-flappy/main.c
@@ -31,9 +31,6 @@ extern volatile uint32_t MISC[];
 extern volatile uint32_t GFXREG[];
 #define GFX_REG(i) GFXREG[(i)/4]
 
-//Manually point to sprites memory location
-uint32_t *GFXSPRITES = (uint32_t *)0x5000C000;
-
 //Define some tilemap data
 #define FLAPPY_GROUND_INDEX 247
 #define FLAPPY_GROUND_Y 19

--- a/app-invaders/main.c
+++ b/app-invaders/main.c
@@ -77,9 +77,6 @@ uint32_t m_level = 1;
 uint32_t m_score = 0;
 uint32_t m_counter = 0;
 
-// Manually point to sprites memory location
-uint32_t* GFXSPRITES = (uint32_t*)0x5000C000;
-
 // Borrowed this from lcd.c until a better solution comes along :/
 static void __INEFFICIENT_delay(int n) {
   for (int i = 0; i < n; i++) {


### PR DESCRIPTION
Remove (now) duplicate GFXSPRITES declaration to resolve #147 

Previously, GFXSPRITES was manually declared in each main.c. Commit 251348f added a declaration to apps-sdk/sdk.h so the manual declaration now triggers a compiler error.

```
     CC main.c
/home/roger/coding/hadbadge2019_fpgasoc/app-badgetris/main.c:37:11: error: conflicting types for 'GFXSPRITES'
   37 | uint32_t *GFXSPRITES = (uint32_t *)0x5000C000;
      |           ^~~~~~~~~~
In file included from /home/roger/coding/hadbadge2019_fpgasoc/app-badgetris/main.c:7:
../apps-sdk/sdk.h:45:17: note: previous declaration of 'GFXSPRITES' was here
   45 | extern uint32_t GFXSPRITES[];
      |                 ^~~~~~~~~~
../apps-sdk/sdk.mk:82: recipe for target '/home/roger/coding/hadbadge2019_fpgasoc/app-badgetris/build/main.o' failed
make: *** [/home/roger/coding/hadbadge2019_fpgasoc/app-badgetris/build/main.o] Error 1
```