### PR TITLE
Add minimal support for C++ source files in SDK

### DIFF
--- a/apps-sdk/sdk.mk
+++ b/apps-sdk/sdk.mk
@@ -19,10 +19,11 @@ BUILD_DIR_SDK := $(BUILD_DIR)/apps-sdk
 #Ipl gloss is in include path because mach_defines.h
 INCLUDEDIRS += $(APPSSDK_DIR) $(APPSSDK_DIR)/gloss $(APPSSDK_DIR)/../soc/ipl/gloss $(APPSSDK_DIR)/../soc/ipl/syscallable/
 CFLAGS += -ggdb $(addprefix -I,$(INCLUDEDIRS))
+CPPFLAGS += -ggdb $(addprefix -I,$(INCLUDEDIRS))
 LDFLAGS += -ggdb -Wl,-T,$(LDSCRIPT) -Wl,-Map,$(TARGET_MAP) -lgcc -lm -lgloss
 DEPFLAGS := -MMD -MP 
 
-export CC AR LD OBJCOPY CFLAGS LDFLAGS APPNAME
+export CC CPP AR LD OBJCOPY CFLAGS CPPFLAGS LDFLAGS APPNAME
 
 #By default, we'll build the elf file.
 default: $(TARGET_ELF)
@@ -71,6 +72,11 @@ $(1)/%.o: $(2)/%.c $(1)/%.d
 	$$(vecho) CC $$(notdir $$<)
 	$$(Q)mkdir -p $$(dir $$@)
 	$$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c -o $$@ $$<
+
+$(1)/%.o: $(2)/%.cpp $(1)/%.d
+	$$(vecho) CPP $$(notdir $$<)
+	$$(Q)mkdir -p $$(dir $$@)
+	$$(Q)$$(CPP) $$(CPPFLAGS) $$(DEPFLAGS) -c -o $$@ $$<
 
 $(1)/%.o: $(2)/%.S $(1)/%.d
 	$$(vecho) CC $$(notdir $$<)

--- a/toolchain-settings.mk
+++ b/toolchain-settings.mk
@@ -45,6 +45,7 @@ endif
 
 # Set prefixes and paths to all tools.
 CC := $(CROSS)gcc$(EXE)
+CPP := $(CROSS)g++$(EXE)
 AR := $(CROSS)gcc-ar$(EXE)
 LD := $(CROSS)ld$(EXE)
 OBJCOPY := $(CROSS)objcopy$(EXE)
@@ -53,6 +54,7 @@ SIZE := $(CROSS)size$(EXE)
 STRIP := $(CROSS)strip$(EXE)
 GDB := $(CROSS)gdb$(EXE)
 
-ASFLAGS := -march=rv32imac -mabi=ilp32
-CFLAGS  := -march=rv32imac -mabi=ilp32 -flto -Os
-LDFLAGS := -march=rv32imac -mabi=ilp32 -flto -ffreestanding -nostartfiles -Wl,--gc-section -Wl,-Bstatic -Wl,-melf32lriscv
+ASFLAGS  := -march=rv32imac -mabi=ilp32
+CFLAGS   := -march=rv32imac -mabi=ilp32 -flto -Os
+CPPFLAGS := -march=rv32imac -mabi=ilp32 -flto -Os
+LDFLAGS  := -march=rv32imac -mabi=ilp32 -flto -ffreestanding -nostartfiles -Wl,--gc-section -Wl,-Bstatic -Wl,-melf32lriscv


### PR DESCRIPTION
I'm porting mixed C/C++ application without STL dependencies, which requires support for compiling C++ sources with the SDK.